### PR TITLE
Fixed purge paths for virtual hosting scenarios using virtual path components.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed purge paths for virtual hosting scenarios using virtual path components.
+  [dokai]
 
 
 1.0.3 (2011-09-16)

--- a/plone/cachepurging/paths.py
+++ b/plone/cachepurging/paths.py
@@ -8,15 +8,15 @@ from OFS.interfaces import ITraversable
 class TraversablePurgePaths(object):
     """Default purge for OFS.Traversable-style objects
     """
-    
+
     implements(IPurgePaths)
     adapts(ITraversable)
-    
+
     def __init__(self, context):
         self.context = context
-        
+
     def getRelativePaths(self):
-        return [self.context.absolute_url_path()]
-    
+        return ['/' + self.context.virtual_url_path()]
+
     def getAbsolutePaths(self):
         return []

--- a/plone/cachepurging/tests/test_traversable_paths.py
+++ b/plone/cachepurging/tests/test_traversable_paths.py
@@ -8,18 +8,18 @@ from OFS.interfaces import ITraversable
 class FauxTraversable(object):
     implements(ITraversable)
 
-    def absolute_url_path(self):
-        return '/foo'
+    def virtual_url_path(self):
+        return 'foo'
 
 class TestTraversablePaths(unittest.TestCase):
-    
+
     def test_traversable_paths(self):
-        
+
         context = FauxTraversable()
         paths = TraversablePurgePaths(context)
-        
+
         self.assertEquals(['/foo'], paths.getRelativePaths())
         self.assertEquals([], paths.getAbsolutePaths())
-        
+
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
...nents.

In case the virtual host setup includes virtual path components which are not
part of the ZODB path hierarchy, the generated purge paths are incorrect.

For example, assuming the following rewrite rule in Apache

  RewriteRule ^/a/b/?(.*)/?$ http://127.0.0.1:5128/VirtualHostBase/http/%{SERVER_NAME}:80/VirtualHostRoot/_vh_a/_vh_b/$1 [P,L]

which contains a two-part virtual path `/a/b` results in the following kind of
of URL to be sent to Varnish

  /VirtualHostBase/http/server.com:80/VirtualHostRoot/_vh_a/_vh_b/plone/my-document

however, when the purge URLs are generated using the `absolute_url_path`
method they look like

  /VirtualHostBase/http/server.com:80/VirtualHostRoot/_vh_a/_vh_b/a/b/plone/my-document

containing the virtual "/a/b" part which does not match with what gets cached in
Varnish.

Instead of using `absolute_url_path` the `virtual_url_path` method should be
used instead to avoid the virtual parts.

Note that `virtual_url_path` does not have a leading slash which needs to be
added explicitly.
