### PR TITLE
Add undeclared dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,15 @@ setup(name='plone.cachepurging',
           'setuptools',
           'five.globalrequest',
           'plone.registry',
+          'z3c.caching'
           'zope.annotation',
           'zope.component',
           'zope.event',
           'zope.i18nmessageid',
           'zope.interface',
           'zope.lifecycleevent',
+          'zope.schema'
+          'zope.testing'  # on purger.py not on tests
           'Zope2',
       ],
       extras_require={


### PR DESCRIPTION
While trying a buildout on a project I noticed that it was failing due to `z3c.caching` not being declared as a dependency (and as `plone.app.caching` was not used it was not indirectly injected into buidlout).

On a side note I saw that there's an import for `zope.testing` outside tests on `purger.py`, is that supposed to be there?

If I have time I will prepare a new pull request to add travis support.
