### PR TITLE
Change i18n_domain to "plone"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Changelog
 1.0.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Change i18n_domain to "plone"
+  [staeff]
 
 1.0.9 (2015-07-18)
 ------------------

--- a/plone/cachepurging/configure.zcml
+++ b/plone/cachepurging/configure.zcml
@@ -1,7 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="plone.cachepurging">
+    i18n_domain="plone">
 
     <include package="zope.annotation" />
     <include package="five.globalrequest" />

--- a/plone/cachepurging/interfaces.py
+++ b/plone/cachepurging/interfaces.py
@@ -3,7 +3,7 @@ from zope import schema
 
 from zope.i18nmessageid import MessageFactory
 
-_ = MessageFactory('plone.cachepurging')
+_ = MessageFactory('plone')
 
 class ICachePurgingSettings(Interface):
     """Settings used by the purging algorithm.


### PR DESCRIPTION
Use the "plone" i18n domain now as proposed in plone/Products.CMFPlone#983. Nothing else needed to be done. There were no translation files.