### PR TITLE
consider purging to be enabled when it’s enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,10 @@ Changelog
 1.0.15 (unreleased)
 -------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
 Bug fixes:
 
-- *add item here*
+- consider purging to be enabled when it’s enabled (even if no servers are listed)
+  [skurfer]
 
 
 1.0.14 (2018-01-30)

--- a/plone/cachepurging/utils.py
+++ b/plone/cachepurging/utils.py
@@ -17,7 +17,7 @@ def isCachePurgingEnabled(registry=None):
         return False
 
     settings = registry.forInterface(ICachePurgingSettings, check=False)
-    return (settings.enabled and bool(settings.cachingProxies))
+    return settings.enabled
 
 
 def getPathsToPurge(context, request):


### PR DESCRIPTION
If you’re using Amazon’s CloudFront, you won’t have a list of servers (because purging is done via an API call), but you might want to access the manual purging control panel.