### PR TITLE
Try to avoid port collisions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Try to avoid port collisions when running tests.
+  [gforcada]
 
 Bug fixes:
 


### PR DESCRIPTION
On our CI environment it seems that every now and then these tests fail because the port it tries to bind to is already in use, see https://github.com/plone/plone.cachepurging/issues/16